### PR TITLE
Fix: changed the port mapping from 8080 to 443

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,6 @@ services:
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
-      - "8080:80"
+      - "443:80"
     depends_on:
       - app


### PR DESCRIPTION
Turns out 8080 was not a valid inbound port for the Azure Linux Virtual Machine, so I had to find the valid inbound port for HTTPS, which was 443.